### PR TITLE
Permet de spécifier --nodm lors de leon!help

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -45,8 +45,11 @@ leon!embed <texte>""",
         embed.add_field(name="Informations ❓",
                         value="leon!info",
                         inline=False)
-        await message.author.send(embed=embed)
-        await message.add_reaction("👍")
+        if "--nodm" in message.content:
+            await message.channel.send(embed=embed)
+        else:
+            await message.author.send(embed=embed)
+            await message.add_reaction("👍")
 
     if message.content.startswith(prefix + 'gay'):
 


### PR DESCRIPTION
Cela envoie alors l'aide dans le salon de la commande, plutôt que en mp